### PR TITLE
Remove logPartWork from document model

### DIFF
--- a/Model/Document.php
+++ b/Model/Document.php
@@ -130,11 +130,6 @@ class Document
     private $related = [];
 
     /**
-     * @var array
-     */
-    private $logPartWork = [];
-
-    /**
      * @var string
      */
     private $permaLink;
@@ -668,26 +663,6 @@ class Document
     public function setIssue(string $issue): self
     {
         $this->issue = $issue;
-
-        return $this;
-    }
-
-    /**
-     * @return array
-     */
-    public function getLogPartWork(): array
-    {
-        return $this->logPartWork;
-    }
-
-    /**
-     * @param array $logPartWork
-     *
-     * @return Document
-     */
-    public function setLogPartWork(array $logPartWork): self
-    {
-        $this->logPartWork = $logPartWork;
 
         return $this;
     }


### PR DESCRIPTION
This removes logPartWork from document model since logPartWork
parameter has been removed from the Solr Index.